### PR TITLE
fix: search dedup, doc title resolution, FTS5 wildcard

### DIFF
--- a/src/tools/build-legal-stance.ts
+++ b/src/tools/build-legal-stance.ts
@@ -5,6 +5,7 @@
 
 import type { Database } from '@ansvar/mcp-sqlite';
 import { buildFtsQueryVariantsLegacy as buildFtsQueryVariants } from '../utils/fts-query.js';
+import { resolveDocumentId } from '../utils/statute-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 
 export interface BuildLegalStanceInput {
@@ -44,11 +45,29 @@ export async function buildLegalStance(
   }
 
   const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+  // Fetch extra rows to account for deduplication
+  const fetchLimit = limit * 2;
   const queryVariants = buildFtsQueryVariants(input.query);
+
+  // Resolve document_id from title if provided
+  let resolvedDocId: string | undefined;
+  if (input.document_id) {
+    const resolved = resolveDocumentId(db as any, input.document_id);
+    resolvedDocId = resolved ?? undefined;
+    if (!resolved) {
+      return {
+        results: { query: input.query, provisions: [], total_citations: 0 },
+        _metadata: {
+          ...generateResponseMetadata(db),
+          note: `No document found matching "${input.document_id}"`,
+        },
+      };
+    }
+  }
 
   // For short queries, use LIKE-based search
   if (queryVariants.use_like) {
-    return buildStanceWithLike(db, input, limit);
+    return buildStanceWithLike(db, input, fetchLimit, limit, resolvedDocId);
   }
 
   let provSql = `
@@ -67,23 +86,26 @@ export async function buildLegalStance(
 
   const provParams: (string | number)[] = [];
 
-  if (input.document_id) {
+  if (resolvedDocId) {
     provSql += ` AND lp.document_id = ?`;
-    provParams.push(input.document_id);
+    provParams.push(resolvedDocId);
   }
 
   provSql += ` ORDER BY relevance LIMIT ?`;
-  provParams.push(limit);
+  provParams.push(fetchLimit);
 
   const runProvisionQuery = (ftsQuery: string): ProvisionHit[] => {
     const bound = [ftsQuery, ...provParams];
     return db.prepare(provSql).all(...bound) as ProvisionHit[];
   };
 
-  let provisions = runProvisionQuery(queryVariants.primary);
-  if (provisions.length === 0 && queryVariants.fallback) {
-    provisions = runProvisionQuery(queryVariants.fallback);
-  }
+  const primaryResults = runProvisionQuery(queryVariants.primary);
+  const usedFallback = primaryResults.length === 0 && !!queryVariants.fallback;
+  const rawProvisions = usedFallback
+    ? runProvisionQuery(queryVariants.fallback!)
+    : primaryResults;
+
+  const provisions = deduplicateResults(rawProvisions, limit);
 
   return {
     results: {
@@ -91,7 +113,10 @@ export async function buildLegalStance(
       provisions,
       total_citations: provisions.length,
     },
-    _metadata: generateResponseMetadata(db)
+    _metadata: {
+      ...generateResponseMetadata(db),
+      ...(usedFallback ? { query_strategy: 'broadened' } : {}),
+    },
   };
 }
 
@@ -99,7 +124,9 @@ export async function buildLegalStance(
 function buildStanceWithLike(
   db: Database,
   input: BuildLegalStanceInput,
+  fetchLimit: number,
   limit: number,
+  resolvedDocId?: string,
 ): ToolResponse<LegalStanceResult> {
   let sql = `
     SELECT
@@ -116,15 +143,16 @@ function buildStanceWithLike(
 
   const params: (string | number)[] = [`%${input.query.trim()}%`];
 
-  if (input.document_id) {
+  if (resolvedDocId) {
     sql += ` AND lp.document_id = ?`;
-    params.push(input.document_id);
+    params.push(resolvedDocId);
   }
 
   sql += ` LIMIT ?`;
-  params.push(limit);
+  params.push(fetchLimit);
 
-  const provisions = db.prepare(sql).all(...params) as ProvisionHit[];
+  const rows = db.prepare(sql).all(...params) as ProvisionHit[];
+  const provisions = deduplicateResults(rows, limit);
 
   return {
     results: {
@@ -132,6 +160,30 @@ function buildStanceWithLike(
       provisions,
       total_citations: provisions.length,
     },
-    _metadata: generateResponseMetadata(db)
+    _metadata: {
+      ...generateResponseMetadata(db),
+      query_strategy: 'like_fallback',
+    },
   };
+}
+
+/**
+ * Deduplicate results by document_title + provision_ref.
+ * Duplicate document IDs (numeric vs slug) cause the same provision to appear twice.
+ * Keeps the first (highest-ranked) occurrence.
+ */
+function deduplicateResults(
+  rows: ProvisionHit[],
+  limit: number,
+): ProvisionHit[] {
+  const seen = new Set<string>();
+  const deduped: ProvisionHit[] = [];
+  for (const row of rows) {
+    const key = `${row.document_title}::${row.provision_ref}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(row);
+    if (deduped.length >= limit) break;
+  }
+  return deduped;
 }

--- a/src/tools/search-legislation.ts
+++ b/src/tools/search-legislation.ts
@@ -7,6 +7,7 @@
 import type { Database } from '@ansvar/mcp-sqlite';
 import { buildFtsQueryVariantsLegacy as buildFtsQueryVariants } from '../utils/fts-query.js';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
+import { resolveDocumentId } from '../utils/statute-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 
 export interface SearchLegislationInput {
@@ -43,12 +44,30 @@ export async function searchLegislation(
   }
 
   const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+  // Fetch extra rows to account for deduplication
+  const fetchLimit = limit * 2;
   const queryVariants = buildFtsQueryVariants(input.query);
   if (input.as_of_date) normalizeAsOfDate(input.as_of_date);
 
+  // Resolve document_id from title if provided (same resolution as get_provision)
+  let resolvedDocId: string | undefined;
+  if (input.document_id) {
+    const resolved = resolveDocumentId(db as any, input.document_id);
+    resolvedDocId = resolved ?? undefined;
+    if (!resolved) {
+      return {
+        results: [],
+        _metadata: {
+          ...generateResponseMetadata(db),
+          note: `No document found matching "${input.document_id}"`,
+        },
+      };
+    }
+  }
+
   // For short queries, fall back to LIKE-based search
   if (queryVariants.use_like) {
-    return searchWithLike(db, input, limit);
+    return searchWithLike(db, input, fetchLimit, limit, resolvedDocId);
   }
 
   let sql = `
@@ -69,9 +88,9 @@ export async function searchLegislation(
 
   const params: (string | number)[] = [];
 
-  if (input.document_id) {
+  if (resolvedDocId) {
     sql += ` AND lp.document_id = ?`;
-    params.push(input.document_id);
+    params.push(resolvedDocId);
   }
 
   if (input.status) {
@@ -80,7 +99,7 @@ export async function searchLegislation(
   }
 
   sql += ` ORDER BY relevance LIMIT ?`;
-  params.push(limit);
+  params.push(fetchLimit);
 
   const runQuery = (ftsQuery: string): SearchLegislationResult[] => {
     const bound = [ftsQuery, ...params];
@@ -88,13 +107,17 @@ export async function searchLegislation(
   };
 
   const primaryResults = runQuery(queryVariants.primary);
-  const results = (primaryResults.length > 0 || !queryVariants.fallback)
-    ? primaryResults
-    : runQuery(queryVariants.fallback);
+  const usedFallback = primaryResults.length === 0 && !!queryVariants.fallback;
+  const rawResults = usedFallback
+    ? runQuery(queryVariants.fallback!)
+    : primaryResults;
 
   return {
-    results,
-    _metadata: generateResponseMetadata(db)
+    results: deduplicateResults(rawResults, limit),
+    _metadata: {
+      ...generateResponseMetadata(db),
+      ...(usedFallback ? { query_strategy: 'broadened' } : {}),
+    },
   };
 }
 
@@ -102,7 +125,9 @@ export async function searchLegislation(
 function searchWithLike(
   db: Database,
   input: SearchLegislationInput,
+  fetchLimit: number,
   limit: number,
+  resolvedDocId?: string,
 ): ToolResponse<SearchLegislationResult[]> {
   let sql = `
     SELECT
@@ -121,9 +146,9 @@ function searchWithLike(
 
   const params: (string | number)[] = [`%${input.query.trim()}%`];
 
-  if (input.document_id) {
+  if (resolvedDocId) {
     sql += ` AND lp.document_id = ?`;
-    params.push(input.document_id);
+    params.push(resolvedDocId);
   }
 
   if (input.status) {
@@ -132,12 +157,36 @@ function searchWithLike(
   }
 
   sql += ` LIMIT ?`;
-  params.push(limit);
+  params.push(fetchLimit);
 
-  const results = db.prepare(sql).all(...params) as SearchLegislationResult[];
+  const rows = db.prepare(sql).all(...params) as SearchLegislationResult[];
 
   return {
-    results,
-    _metadata: generateResponseMetadata(db)
+    results: deduplicateResults(rows, limit),
+    _metadata: {
+      ...generateResponseMetadata(db),
+      query_strategy: 'like_fallback',
+    },
   };
+}
+
+/**
+ * Deduplicate search results by document_title + provision_ref.
+ * Duplicate document IDs (numeric vs slug) cause the same provision to appear twice.
+ * Keeps the first (highest-ranked) occurrence.
+ */
+function deduplicateResults(
+  rows: SearchLegislationResult[],
+  limit: number,
+): SearchLegislationResult[] {
+  const seen = new Set<string>();
+  const deduped: SearchLegislationResult[] = [];
+  for (const row of rows) {
+    const key = `${row.document_title}::${row.provision_ref}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(row);
+    if (deduped.length >= limit) break;
+  }
+  return deduped;
 }

--- a/src/utils/fts-query.ts
+++ b/src/utils/fts-query.ts
@@ -60,8 +60,10 @@ export function sanitizeFtsInput(input: string): string {
   }
 
   // Standard mode: aggressive strip
+  // Preserve trailing * on words (FTS5 prefix search) but strip other special chars
   const cleaned = input
-    .replace(/['"(){}[\]^~*:@#$%&+=<>|\\/.!?,;]/g, ' ')
+    .replace(/['"(){}[\]^~:@#$%&+=<>|\\/.!?,;]/g, ' ')
+    .replace(/\*(?!\s|$)/g, ' ')    // strip * unless at end of word
     .replace(/\s+/g, ' ')
     .trim();
 

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -8,6 +8,8 @@ export interface ResponseMetadata {
   data_freshness: string;
   disclaimer: string;
   source_authority: string;
+  note?: string;
+  query_strategy?: string;
 }
 
 export interface ToolResponse<T> {


### PR DESCRIPTION
## Summary

- **P0 — Deduplicate search results**: Documents with both numeric and slug IDs caused duplicates. Added `deduplicateResults()` to both `search_legislation` and `build_legal_stance`, fetching `limit * 2` rows then deduplicating by `document_title + provision_ref`. This MCP had 21.7% duplicate documents.
- **P1 — Preserve FTS5 prefix wildcard**: `sanitizeFtsInput()` stripped `*` character, breaking prefix search like `control*`. Fixed regex to preserve trailing `*` on words.
- **P1 — Document ID title resolution**: `search_legislation` and `build_legal_stance` used raw `document_id = ?` without resolving Act titles. Now imports and uses `resolveDocumentId` from `utils/statute-id.js`.
- **P2 — Silent fallback disclosure**: When queries fall back to broader matching, `query_strategy: 'broadened'` or `'like_fallback'` is now included in `_metadata`.
- **CI — ResponseMetadata type**: Added `note?: string` and `query_strategy?: string` to `ResponseMetadata` interface.

## Test plan

- [x] `npm run lint` passes (tsc --noEmit)
- [x] `npm test` passes (49/49 tests)
- [x] HTTP transport: dedup verified (0 duplicates in search results)
- [x] HTTP transport: doc ID resolution works with Chinese title
- [x] HTTP transport: query_strategy disclosed on fallback
- [x] HTTP transport: SQL injection safely handled
- [x] get_provision regression check passed

Generated with [Claude Code](https://claude.com/claude-code)