### PR TITLE
fix: replace buildFtsQueryVariantsLegacy with tiered FTS5 search pattern

### DIFF
--- a/src/tools/search-legislation.ts
+++ b/src/tools/search-legislation.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Database } from '@ansvar/mcp-sqlite';
-import { buildFtsQueryVariantsLegacy as buildFtsQueryVariants } from '../utils/fts-query.js';
+import { buildFtsQueryVariants, buildLikePattern, sanitizeFtsInput } from '../utils/fts-query.js';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
 import { resolveDocumentId } from '../utils/statute-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
@@ -46,7 +46,7 @@ export async function searchLegislation(
   const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
   // Fetch extra rows to account for deduplication
   const fetchLimit = limit * 2;
-  const queryVariants = buildFtsQueryVariants(input.query);
+  const queryVariants = buildFtsQueryVariants(sanitizeFtsInput(input.query));
   if (input.as_of_date) normalizeAsOfDate(input.as_of_date);
 
   // Resolve document_id from title if provided (same resolution as get_provision)
@@ -65,109 +65,106 @@ export async function searchLegislation(
     }
   }
 
-  // For short queries, fall back to LIKE-based search
-  if (queryVariants.use_like) {
-    return searchWithLike(db, input, fetchLimit, limit, resolvedDocId);
+  let queryStrategy = 'none';
+  for (const ftsQuery of queryVariants) {
+    let sql = `
+      SELECT
+        lp.document_id,
+        ld.title as document_title,
+        lp.provision_ref,
+        lp.chapter,
+        lp.section,
+        lp.title,
+        snippet(provisions_fts, 0, '>>>', '<<<', '...', 32) as snippet,
+        bm25(provisions_fts) as relevance
+      FROM provisions_fts
+      JOIN legal_provisions lp ON lp.id = provisions_fts.rowid
+      JOIN legal_documents ld ON ld.id = lp.document_id
+      WHERE provisions_fts MATCH ?
+    `;
+    const params: (string | number)[] = [ftsQuery];
+
+    if (resolvedDocId) {
+      sql += ' AND lp.document_id = ?';
+      params.push(resolvedDocId);
+    }
+
+    if (input.status) {
+      sql += ' AND ld.status = ?';
+      params.push(input.status);
+    }
+
+    sql += ' ORDER BY relevance LIMIT ?';
+    params.push(fetchLimit);
+
+    try {
+      const rows = db.prepare(sql).all(...params) as SearchLegislationResult[];
+      if (rows.length > 0) {
+        queryStrategy = ftsQuery === queryVariants[0] ? 'exact' : 'fallback';
+        const deduped = deduplicateResults(rows, limit);
+        return {
+          results: deduped,
+          _metadata: {
+            ...generateResponseMetadata(db),
+            ...(queryStrategy === 'fallback' ? { query_strategy: 'broadened' } : {}),
+          },
+        };
+      }
+    } catch {
+      // FTS query syntax error — try next variant
+      continue;
+    }
   }
 
-  let sql = `
-    SELECT
-      lp.document_id,
-      ld.title as document_title,
-      lp.provision_ref,
-      lp.chapter,
-      lp.section,
-      lp.title,
-      snippet(provisions_fts, 0, '>>>', '<<<', '...', 32) as snippet,
-      bm25(provisions_fts) as relevance
-    FROM provisions_fts
-    JOIN legal_provisions lp ON lp.id = provisions_fts.rowid
-    JOIN legal_documents ld ON ld.id = lp.document_id
-    WHERE provisions_fts MATCH ?
-  `;
+  // LIKE fallback — final tier when all FTS5 variants return no results
+  {
+    const likePattern = buildLikePattern(input.query.trim());
+    let likeSql = `
+      SELECT
+        lp.document_id,
+        ld.title as document_title,
+        lp.provision_ref,
+        lp.chapter,
+        lp.section,
+        lp.title,
+        substr(lp.content, 1, 200) as snippet,
+        0 as relevance
+      FROM legal_provisions lp
+      JOIN legal_documents ld ON ld.id = lp.document_id
+      WHERE lp.content LIKE ?
+    `;
+    const likeParams: (string | number)[] = [likePattern];
 
-  const params: (string | number)[] = [];
+    if (resolvedDocId) {
+      likeSql += ' AND lp.document_id = ?';
+      likeParams.push(resolvedDocId);
+    }
 
-  if (resolvedDocId) {
-    sql += ` AND lp.document_id = ?`;
-    params.push(resolvedDocId);
+    if (input.status) {
+      likeSql += ' AND ld.status = ?';
+      likeParams.push(input.status);
+    }
+
+    likeSql += ' LIMIT ?';
+    likeParams.push(fetchLimit);
+
+    try {
+      const rows = db.prepare(likeSql).all(...likeParams) as SearchLegislationResult[];
+      if (rows.length > 0) {
+        return {
+          results: deduplicateResults(rows, limit),
+          _metadata: {
+            ...generateResponseMetadata(db),
+            query_strategy: 'like_fallback',
+          },
+        };
+      }
+    } catch {
+      // LIKE query failed — fall through to empty return
+    }
   }
 
-  if (input.status) {
-    sql += ` AND ld.status = ?`;
-    params.push(input.status);
-  }
-
-  sql += ` ORDER BY relevance LIMIT ?`;
-  params.push(fetchLimit);
-
-  const runQuery = (ftsQuery: string): SearchLegislationResult[] => {
-    const bound = [ftsQuery, ...params];
-    return db.prepare(sql).all(...bound) as SearchLegislationResult[];
-  };
-
-  const primaryResults = runQuery(queryVariants.primary);
-  const usedFallback = primaryResults.length === 0 && !!queryVariants.fallback;
-  const rawResults = usedFallback
-    ? runQuery(queryVariants.fallback!)
-    : primaryResults;
-
-  return {
-    results: deduplicateResults(rawResults, limit),
-    _metadata: {
-      ...generateResponseMetadata(db),
-      ...(usedFallback ? { query_strategy: 'broadened' } : {}),
-    },
-  };
-}
-
-/** LIKE-based fallback for queries too short for trigram FTS5 */
-function searchWithLike(
-  db: Database,
-  input: SearchLegislationInput,
-  fetchLimit: number,
-  limit: number,
-  resolvedDocId?: string,
-): ToolResponse<SearchLegislationResult[]> {
-  let sql = `
-    SELECT
-      lp.document_id,
-      ld.title as document_title,
-      lp.provision_ref,
-      lp.chapter,
-      lp.section,
-      lp.title,
-      substr(lp.content, 1, 200) as snippet,
-      0 as relevance
-    FROM legal_provisions lp
-    JOIN legal_documents ld ON ld.id = lp.document_id
-    WHERE lp.content LIKE ?
-  `;
-
-  const params: (string | number)[] = [`%${input.query.trim()}%`];
-
-  if (resolvedDocId) {
-    sql += ` AND lp.document_id = ?`;
-    params.push(resolvedDocId);
-  }
-
-  if (input.status) {
-    sql += ` AND ld.status = ?`;
-    params.push(input.status);
-  }
-
-  sql += ` LIMIT ?`;
-  params.push(fetchLimit);
-
-  const rows = db.prepare(sql).all(...params) as SearchLegislationResult[];
-
-  return {
-    results: deduplicateResults(rows, limit),
-    _metadata: {
-      ...generateResponseMetadata(db),
-      query_strategy: 'like_fallback',
-    },
-  };
+  return { results: [], _metadata: generateResponseMetadata(db) };
 }
 
 /**


### PR DESCRIPTION
## Summary

`search-legislation.ts` was importing `buildFtsQueryVariantsLegacy` which always returns `use_like: true`, causing the handler to skip FTS5 entirely and execute a LIKE search instead. A LIKE search for `刑法 OR 民法` looks for the literal string `刑法 OR 民法` in content — this never matches, returning empty.

## Changes

- Replace `buildFtsQueryVariantsLegacy` import with `buildFtsQueryVariants`, `buildLikePattern`, `sanitizeFtsInput`
- Rewrite search handler to use the standard tiered loop over `string[]` variants (matches fleet-wide golden standard)
- FTS5 now runs with `sanitizeFtsInput` → `buildFtsQueryVariants` → tiered variants
- LIKE fallback added as last resort

## Root cause

The fleet-wide FTS5 fix updated `fts-query.ts` correctly but missed changing the import in `search-legislation.ts` from the legacy wrapper. The legacy wrapper sets `use_like: true` unconditionally, bypassing all FTS5 logic.

## Test plan

- [ ] Vercel deploys on merge to main
- [ ] Re-run: `./scripts/fleet-audit-scan.sh --filter chinese-law`
- [ ] Verify A1 boolean_or: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)