### PR TITLE
fix: fleet audit corrections — metadata, version, corpus stats, docs, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - dev
       - 'feature/*'
       - 'fix/*'
   pull_request:
     branches:
       - main
+      - dev
   schedule:
     - cron: '0 6 * * 1'
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,6 +1,6 @@
 # Tools — Chinese Law MCP
 
-8 tools for searching and retrieving Chinese legislation.
+10 tools for searching and retrieving Chinese legislation.
 
 ---
 
@@ -107,3 +107,19 @@ Check whether a statute or provision is currently in force.
 Server metadata, dataset statistics, and data freshness.
 
 **Returns:** Document/provision counts, build date, source authority, and database version.
+
+---
+
+## 9. list_provinces
+
+List all provinces with legislation in the database, including document counts.
+
+**Returns:** Array of provinces with name, code, and law count, plus total count.
+
+---
+
+## 10. list_categories
+
+List all legal categories in the database, including document and provision counts.
+
+**Returns:** Array of categories with name, type, document count, and provision count.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ansvar/chinese-law-mcp",
   "mcpName": "eu.ansvar/chinese-law-mcp",
   "version": "3.0.0",
-  "description": "Chinese law MCP server — 1,188 national laws, administrative regulations, and departmental rules with 62,981 provisions from NPC National Law Database (flk.npc.gov.cn) and CAC (cac.gov.cn). Full-text search, citation validation, legal stance builder. Part of Ansvar Open Law (ansvar.eu/open-law) and the Ansvar MCP Network (ansvar.ai/mcp).",
+  "description": "Chinese law MCP server — 19,185 national laws, administrative regulations, and departmental rules with 797,450 provisions from NPC National Law Database (flk.npc.gov.cn) and CAC (cac.gov.cn). Full-text search, citation validation, legal stance builder. Part of Ansvar Open Law (ansvar.eu/open-law) and the Ansvar MCP Network (ansvar.ai/mcp).",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { detectCapabilities, readDbMetadata } from './capabilities.js';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const SERVER_NAME = 'chinese-law-mcp';
-const SERVER_VERSION = '2.3.0';
+const SERVER_VERSION = '3.0.0';
 const DB_ENV_VAR = 'CHINESE_LAW_DB_PATH';
 
 function resolveDbPath(): string {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -19,6 +19,7 @@ import { buildLegalStance, BuildLegalStanceInput } from './build-legal-stance.js
 import { formatCitationTool, FormatCitationInput } from './format-citation.js';
 import { checkCurrency, CheckCurrencyInput } from './check-currency.js';
 import { getAbout, type AboutContext } from './about.js';
+import { generateResponseMetadata } from '../utils/metadata.js';
 export type { AboutContext } from './about.js';
 
 const ABOUT_TOOL: Tool = {
@@ -283,7 +284,7 @@ export function registerTools(
             GROUP BY province_code
             ORDER BY law_count DESC
           `).all();
-          result = { provinces: rows, total: rows.length };
+          result = { provinces: rows, total: rows.length, _metadata: generateResponseMetadata(db) };
           break;
         }
         case 'list_categories': {
@@ -295,7 +296,7 @@ export function registerTools(
             GROUP BY category
             ORDER BY document_count DESC
           `).all();
-          result = { categories: rows };
+          result = { categories: rows, _metadata: generateResponseMetadata(db) };
           break;
         }
         case 'about':


### PR DESCRIPTION
## Summary

- **`src/tools/registry.ts`** — Added `_metadata: generateResponseMetadata(db)` to `list_provinces` and `list_categories` inline handlers (import added)
- **`src/index.ts`** — Fixed `SERVER_VERSION` constant: `'2.3.0'` → `'3.0.0'` to match `package.json`
- **`package.json`** — Updated description with accurate corpus counts: 19,185 laws and 797,450 provisions
- **`TOOLS.md`** — Added documentation for `list_provinces` (tool 9) and `list_categories` (tool 10); corrected header count from 8 → 10
- **`.github/workflows/ci.yml`** — Added `dev` to push branch triggers and pull_request targets per fleet branching strategy

## Test plan

- [ ] `npm run build` — TypeScript compilation succeeds with new `generateResponseMetadata` import
- [ ] `npm test` — existing tests pass
- [ ] Verify `list_provinces` and `list_categories` tool responses include `_metadata` field
- [ ] Verify CI workflow triggers on pushes to `dev` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)