### PR TITLE
fix: upgrade trivy-action 0.34.0 → 0.35.0 (CVE-2026-33634, SLA breached)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm audit --omit=dev --audit-level=high
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner (filesystem)
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -39,7 +39,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy for npm dependencies
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## Summary

- Upgrades `aquasecurity/trivy-action` from `0.34.0` to `0.35.0` in `trivy.yml` (both steps)
- Pins `security.yml` from `@master` to `@0.35.0` (was unpinned and drawing from compromised range)

## Vulnerability

**GHSA-69fq-xp46-6x23 / CVE-2026-33634** — Trivy ecosystem supply chain briefly compromised. Patched in `0.35.0`.

- Severity: Critical
- SLA deadline: 2026-03-31 (7-day critical SLA from detection 2026-03-24)
- **SLA STATUS: BREACHED by 5 days (today: 2026-04-05)**

## Test plan

- [ ] CI passes on this branch
- [ ] Trivy scan runs without error in workflow
- [ ] No `aquasecurity/trivy-action` versions below `0.35.0` remain in any workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)